### PR TITLE
Made api call for representing vendors schedule as deliveries

### DIFF
--- a/clients/webclient/src/api/api.ts
+++ b/clients/webclient/src/api/api.ts
@@ -304,6 +304,12 @@ export class Api {
         const response = await this.apiAxios.post(urlPrefix + "/cancelDeliveries", deliveries);
         return response.status == 200;
     }
+
+    async scheduleToDates(vendorId: string, startDate: string): Promise<interfaces.Delivery[]> {
+        await this.ensureFreshToken();
+        const deliveries = await this.apiAxios.get(urlPrefix + "/scheduleDates?vendorId=" + encodeURIComponent(vendorId) + "&startDate=" + startDate);
+        return deliveries.data;
+    }
 }
 let api = new Api();
 export default api;

--- a/clients/webclient/src/components/Users/CustomerOrder.vue
+++ b/clients/webclient/src/components/Users/CustomerOrder.vue
@@ -259,7 +259,6 @@ export default class CustomerOrder extends Vue {
     async getVendor() {
         this.vendor = await api.getSingleVendor();
         if (this.vendor) {
-            console.log(this.vendor)
             this.deliveryDays = this.vendor.schedule;
         }
     }

--- a/clients/webclient/src/components/Users/CustomerOverview.vue
+++ b/clients/webclient/src/components/Users/CustomerOverview.vue
@@ -109,9 +109,8 @@ export default class CustomerOverview extends Vue {
     }
 
     async populateCalendar() {
-        // Vendor sin schedule hentet fra subscription kan brukes når man skal hente inn vendor sin schedule som events i kalenderen:
         let sub = await api.getSingleSubscription();
-        let schedule = sub.schedule;
+        let usersSchedule = sub.schedule;
 
         let events: any[] = [];
         if (this.start && this.end) {
@@ -120,7 +119,7 @@ export default class CustomerOverview extends Vue {
                 deliveries.forEach((del) => {
                     const delStart = new Date(`${del.deliverytime.substring(0, 10)}T00:00:00`);
                     const delEnd = new Date(`${del.deliverytime.substring(0, 10)}T23:59:59`);
-                    const menu = schedule.find(({ id }) => id == del.menuId);
+                    const menu = usersSchedule.find(({ id }) => id == del.menuId);
                     events.push({
                         name: del.cancelled? "Kansellert" : menu!.menu,
                         start: delStart,

--- a/server/serverless.yml
+++ b/server/serverless.yml
@@ -160,6 +160,14 @@ functions:
           authorizer: authorizer
           path: /cancelDeliveries
           method: post
+  scheduleToDates:
+    handler: src/scheduleToDates.mainHandler
+    events:
+      - http:
+          authorizer: authorizer
+          path: /scheduleDates
+          method: get
+
 
 resources:
   Resources:

--- a/server/src/addDeliveries.ts
+++ b/server/src/addDeliveries.ts
@@ -1,7 +1,7 @@
 import 'source-map-support/register'
-import { Delivery, MenuItems, WeekTime } from './interfaces';
+import { Delivery, MenuItems, Vendor, WeekTime } from './interfaces';
 import { getDeliveryDates } from './timeHandling'
-import { getSubscriptionsForUser } from './dbUtils'
+import { getSubscriptionsForUser, getVendorFromDb } from './dbUtils'
 
 export async function generateDeliveries(EarliestStartDate: Date, userId: string, vendor: string, noOfDeliveries: number): Promise<Delivery[]> {
     let subscriptions = await getSubscriptionsForUser(userId);
@@ -20,6 +20,21 @@ export async function generateDeliveries(EarliestStartDate: Date, userId: string
         return {
             vendorId: vendor,
             userId,
+            deliverytime: date.date.toISOString(),
+            menuId: date.menuId!,
+            cancelled: false
+        }
+    });
+}
+
+export async function generateDeliveriesForVendor(EarliestStartDate: Date, vendor: Vendor, noOfDeliveries: number): Promise<Delivery[]> {
+    let weekTimes:WeekTime[] = scheduleToWeekTimes(vendor.schedule)
+
+    let deliveryDates = getDeliveryDates(EarliestStartDate, weekTimes, noOfDeliveries);
+    return deliveryDates.map((date) => {
+        return {
+            vendorId: vendor.vendorId,
+            userId: vendor.vendorId,
             deliverytime: date.date.toISOString(),
             menuId: date.menuId!,
             cancelled: false

--- a/server/src/scheduleToDates.ts
+++ b/server/src/scheduleToDates.ts
@@ -1,0 +1,30 @@
+import 'source-map-support/register'
+import middy from 'middy';
+import cors from '@middy/http-cors';
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { scheduleToWeekTimes, generateDeliveriesForVendor } from './addDeliveries';
+import { noOfDeliveriesInMonth } from './timeHandling'
+import { getVendorFromDb } from './dbUtils';
+
+async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+    if (!event.queryStringParameters) {
+        return {
+            statusCode: 400,
+            body: '{ "message" : "Missing parameters" }'
+        };
+    }
+    let vendorId = event.queryStringParameters["vendorId"];
+    let startDateString = event.queryStringParameters["startDate"];
+    let startDate = new Date(startDateString);
+    let vendor = await getVendorFromDb(vendorId);
+    let weekTimes = scheduleToWeekTimes(vendor.schedule);
+    let noOfDeliveries = noOfDeliveriesInMonth(startDate, weekTimes);
+    let deliveries = await generateDeliveriesForVendor(startDate, vendor, noOfDeliveries);
+
+    return {
+        statusCode: 200,
+        body: JSON.stringify(deliveries)
+    }
+
+}
+export const mainHandler = middy(handler).use(cors());


### PR DESCRIPTION
Har lagd en metode i api, scheduleToDates, som lar oss skrive inn en vendorId og startdato får måneden og så returnerer den vendor sin schedule som potensielle leveranser som vi kan ha i kalenderen i kundens oversikt. 